### PR TITLE
Add CSRF protection, secure cookie settings, POST-based clicks with validation, and env-based dev middleware

### DIFF
--- a/bandit-ring/src/bandit/ring/app.clj
+++ b/bandit-ring/src/bandit/ring/app.clj
@@ -1,6 +1,7 @@
 (ns bandit.ring.app
   (:use [compojure.core]
         [ring.middleware stacktrace reload cookies]
+        [ring.middleware.anti-forgery :only (wrap-anti-forgery)]
         [ring.util.response]
         [ring.adapter.jetty :only (run-jetty)]
         [ring.middleware.resource :only (wrap-resource)])
@@ -27,12 +28,25 @@
       (if (get cookies "userid")
         resp
         (-> resp
-            (set-cookie "userid" (.toString (java.util.UUID/randomUUID))))))))
+            (set-cookie "userid"
+                        (.toString (java.util.UUID/randomUUID))
+                        {:http-only true
+                         :same-site :lax
+                         :secure (= :https (:scheme request))
+                         :path "/"}))))))
+
+(defn wrap-dev-middleware
+  [handler]
+  (if (= "dev" (System/getenv "BANDIT_ENV"))
+    (-> handler
+        (wrap-reload '(bandit.ring app adverts rank))
+        (wrap-stacktrace))
+    handler))
 
 (def app (-> (routes main-routes ads/advert-example-routes rank/rank-example-routes)
-             (wrap-reload '(bandit.ring app adverts rank))
-             (wrap-stacktrace)
+             (wrap-dev-middleware)
              (wrap-resource "public")
+             (wrap-anti-forgery)
              (wrap-user-cookie)
              (wrap-cookies)))
 

--- a/bandit-ring/src/bandit/ring/example/adverts.clj
+++ b/bandit-ring/src/bandit/ring/example/adverts.clj
@@ -1,30 +1,38 @@
 (ns ^{:doc "Advertisement optimisation example"}
   bandit.ring.example.adverts
   (:use [compojure.core]
-        [ring.util.response :only (redirect)])
+        [ring.util.response :only (redirect response status)])
   (:require [bandit.arms :as arms]
             [bandit.algo.bayes :as bayes]
             [bandit.ring.page :as page]
-            [hiccup.core :as hic]))
+            [hiccup.core :as hic]
+            [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
 (defonce bandit (ref (arms/bandit :advert1 :advert2 :advert3)))
+(def valid-arms #{:advert1 :advert2 :advert3})
 
 (defmulti advertisement :name)
 (defmethod advertisement :advert1
   [_]
   [:div.advert
    [:h3 "Advert 1"]
-   [:a {:href "/ads/click/advert1"} "Buy Now"]])
+   [:form {:action "/ads/click/advert1" :method "POST"}
+    (anti-forgery-field)
+    [:button {:type "submit"} "Buy Now"]]])
 (defmethod advertisement :advert2
   [_]
   [:div.advert
    [:h3 "Advert 2"]
-   [:a {:href "/ads/click/advert2"} "More Info"]])
+   [:form {:action "/ads/click/advert2" :method "POST"}
+    (anti-forgery-field)
+    [:button {:type "submit"} "More Info"]]])
 (defmethod advertisement :advert3
   [_]
   [:div.advert
    [:h3 "Advert 3"]
-   [:a {:href "/ads/click/advert3"} "Apply Now"]])
+   [:form {:action "/ads/click/advert3" :method "POST"}
+    (anti-forgery-field)
+    [:button {:type "submit"} "Apply Now"]]])
 
 (defn record-pull
   [arm-state {:keys [name] :as arm}]
@@ -33,6 +41,12 @@
 (defn record-click
   [arm-state arm-name]
   (update-in arm-state [arm-name] bayes/reward 1))
+
+(defn parse-arm-name
+  [arm-name]
+  (let [arm (keyword arm-name)]
+    (when (contains? valid-arms arm)
+      arm)))
 
 (defn advert-html
   "Uses the bandit algorithm to optimise which advert to show
@@ -52,6 +66,10 @@
                      [:p "This example demonstrates using a Bayesian algorithm to optimise advert click-throughs. There are 3 different adverts (with 3 different calls-to-action). The problem is modeled by using each arm to represent each advert. As you click on adverts the algorithm will tend towards picking that advert."]]
                     [:div#main
                      (advert-html)]))
-  (GET "/ads/click/:arm-name" [arm-name]
-       (dosync (alter bandit record-click (keyword arm-name)))
-       (redirect "/ads")))
+  (POST "/ads/click/:arm-name" [arm-name]
+       (if-let [arm (parse-arm-name arm-name)]
+         (do
+           (dosync (alter bandit record-click arm))
+           (redirect "/ads"))
+         (-> (response "Invalid arm")
+             (status 400)))))

--- a/bandit-ring/src/bandit/ring/example/adverts.clj
+++ b/bandit-ring/src/bandit/ring/example/adverts.clj
@@ -8,31 +8,27 @@
             [hiccup.core :as hic]
             [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
-(defonce bandit (ref (arms/bandit :advert1 :advert2 :advert3)))
-(def valid-arms #{:advert1 :advert2 :advert3})
+(def advert-catalog
+  [[:advert1 "Advert 1" "Buy Now"]
+   [:advert2 "Advert 2" "More Info"]
+   [:advert3 "Advert 3" "Apply Now"]])
 
-(defmulti advertisement :name)
-(defmethod advertisement :advert1
-  [_]
-  [:div.advert
-   [:h3 "Advert 1"]
-   [:form {:action "/ads/click/advert1" :method "POST"}
-    (anti-forgery-field)
-    [:button {:type "submit"} "Buy Now"]]])
-(defmethod advertisement :advert2
-  [_]
-  [:div.advert
-   [:h3 "Advert 2"]
-   [:form {:action "/ads/click/advert2" :method "POST"}
-    (anti-forgery-field)
-    [:button {:type "submit"} "More Info"]]])
-(defmethod advertisement :advert3
-  [_]
-  [:div.advert
-   [:h3 "Advert 3"]
-   [:form {:action "/ads/click/advert3" :method "POST"}
-    (anti-forgery-field)
-    [:button {:type "submit"} "Apply Now"]]])
+(def advert-by-name
+  (into {} (for [[arm-name title cta] advert-catalog]
+             [arm-name {:title title :cta cta}])))
+
+(def valid-arms (set (keys advert-by-name)))
+(defonce bandit (ref (apply arms/bandit (map first advert-catalog))))
+
+(defn advertisement
+  [{:keys [name]}]
+  (let [{:keys [title cta]} (get advert-by-name name)
+        arm-name (clojure.core/name name)]
+    [:div.advert
+     [:h3 title]
+     [:form {:action (str "/ads/click/" arm-name) :method "POST"}
+      (anti-forgery-field)
+      [:button {:type "submit"} cta]]]))
 
 (defn record-pull
   [arm-state {:keys [name] :as arm}]

--- a/bandit-ring/src/bandit/ring/example/rank.clj
+++ b/bandit-ring/src/bandit/ring/example/rank.clj
@@ -1,13 +1,15 @@
 (ns ^{:doc "Rank items using a bandit. This could be news articles, search result items, products etc."}
   bandit.ring.example.rank
-  (:use [ring.util.response :only (redirect)]
+  (:use [ring.util.response :only (redirect response status)]
         [compojure.core])
   (:require [bandit.arms :as arms]
             [bandit.algo.bayes :as bayes]
             [bandit.ring.page :as page]
-            [hiccup.core :as hic]))
+            [hiccup.core :as hic]
+            [ring.util.anti-forgery :refer [anti-forgery-field]]))
 
 (defonce bandit (ref (arms/bandit :item1 :item2 :item3 :item4 :item5)))
+(def valid-arms #{:item1 :item2 :item3 :item4 :item5})
 
 (defn map-vals [m f]
   (into {} (for [[k v] m] [k (f v)])))
@@ -28,18 +30,31 @@
      [:ul
       (for [{:keys [name]} (arms/rank :theta (map bayes/estimate-value (vals @bandit)))]
         [:li
-         [:a {:href (str "/rank/click/" (clojure.core/name name))} name]])]]
+         [:form {:action (str "/rank/click/" (clojure.core/name name))
+                 :method "POST"}
+          (anti-forgery-field)
+          [:button {:type "submit"} name]]])]]
     (page/bandit-state @bandit))))
 
 (defn record-click
   [arm-state arm-name]
   (update-in arm-state [arm-name] bayes/reward 1))
 
+(defn parse-arm-name
+  [arm-name]
+  (let [arm (keyword arm-name)]
+    (when (contains? valid-arms arm)
+      arm)))
+
 
 (defroutes rank-example-routes
   (GET "/rank" []
        (page/layout "Ranking items"
                     [:div#main (items-html)]))
-  (GET "/rank/click/:arm-name" [arm-name]
-       (dosync (alter bandit record-click (keyword arm-name)))
-       (redirect "/rank")))
+  (POST "/rank/click/:arm-name" [arm-name]
+       (if-let [arm (parse-arm-name arm-name)]
+         (do
+           (dosync (alter bandit record-click arm))
+           (redirect "/rank"))
+         (-> (response "Invalid arm")
+             (status 400)))))

--- a/bandit-simulate/project.clj
+++ b/bandit-simulate/project.clj
@@ -14,4 +14,4 @@
                    :plugins [[lein-expectations "0.0.8"]]}}
   :main bandit.simulate
   :min-lein-version "2.0.0"
-  :jvm-opts ["-Xmx2G" "-server" "-XX:+UseConcMarkSweepGC"])
+  :jvm-opts ["-Xmx2G" "-server"])


### PR DESCRIPTION
### Motivation
- Improve security by protecting click actions from CSRF and by hardening the user cookie attributes.
- Replace unsafe GET-based click endpoints with POST forms and validate arm names to prevent invalid inputs.
- Enable development-only middleware (reload/stacktrace) driven by an environment variable and remove an obsolete JVM flag.

### Description
- Add `wrap-anti-forgery` to the middleware stack and include `anti-forgery-field` in generated forms for adverts and rank examples. 
- Convert click endpoints from `GET /ads/click/:arm-name` and `GET /rank/click/:arm-name` to `POST` routes and return a `400` response for invalid arm names using new `valid-arms` sets and `parse-arm-name` helpers. 
- Strengthen `wrap-user-cookie` to set `:http-only`, `:same-site :lax`, `:secure` based on request scheme, and explicit `:path` when setting the `userid` cookie. 
- Introduce `wrap-dev-middleware` to conditionally apply `wrap-reload` and `wrap-stacktrace` when `BANDIT_ENV` equals `dev`. 
- Small project config tweak: remove `-XX:+UseConcMarkSweepGC` from `:jvm-opts` in `bandit-simulate/project.clj`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6ae5919c8331b81243d0754f7e9c)