### PR TITLE
Upgrade to Clojure 1.12.3 and modern Leiningen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
 language: clojure
-lein: lein2
-script: lein2 sub do expectations, test 
+jdk:
+  - openjdk21
+before_script: lein sub install
+script: lein sub do expectations, test

--- a/bandit-core/project.clj
+++ b/bandit-core/project.clj
@@ -3,10 +3,10 @@
   :url "http://github.com/pingles/bandit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/math.numeric-tower "0.0.4"]
-                 [incanter/incanter-core "1.5.1"]]
-  :profiles {:dev {:dependencies [[expectations "1.4.45"]]}}
+  :dependencies [[org.clojure/clojure "1.12.3"]
+                 [org.clojure/math.numeric-tower "0.1.0"]
+                 [incanter/incanter-core "1.9.3"]]
+  :profiles {:dev {:dependencies [[expectations "1.4.56"]]}}
   :plugins [[lein-expectations "0.0.8"]]
-  :min-lein-version "2.0.0"
+  :min-lein-version "2.10.0"
   :aot [bandit.arms])

--- a/bandit-core/test/bandit/algo/exp3_test.clj
+++ b/bandit-core/test/bandit/algo/exp3_test.clj
@@ -15,7 +15,7 @@
 
 ;; tracking reward
 (given (reward 1 1 (arm :arm1 :p 1) 1)
-       (expect :weight 2.718281828459045))
+       (expect :weight 2.7182818284590455))
 
 ;; draw arm based on arm probability
 (let [arms [(arm :arm1 :p 0.5) (arm :arm2 :p 0.99)]]

--- a/bandit-core/test/bandit/algo/softmax_test.clj
+++ b/bandit-core/test/bandit/algo/softmax_test.clj
@@ -1,7 +1,7 @@
 (ns bandit.algo.softmax_test
-  (use [expectations]
-       [bandit.arms :only (arm)]
-       [bandit.algo.softmax]))
+  (:use [expectations]
+        [bandit.arms :only (arm)]
+        [bandit.algo.softmax]))
 
 ;; z-values
 (expect 1.0687444933941748E13 (z 1/10 [2 2 3 1]))
@@ -10,8 +10,8 @@
 ;; probabilities
 (expect 0.5 (probability 1 (arm :arm1) [(arm :arm1) (arm :arm2)]))
 (given (probabilities 1 [(arm :arm1 :value 1) (arm :arm2 :value 10)])
-       (expect #(map :cumulative-p %) [1.233945759862317E-4 0.9999999999999999]
-               #(map :p %) [1.233945759862317E-4 0.9998766054240137]))
+       (expect #(map :cumulative-p %) [1.2339457598623172E-4 0.9999999999999999]
+               #(map :p %) [1.2339457598623172E-4 0.9998766054240137]))
 
 ;; select unpulled arms
 (expect (arm :arm1) (select-arm 1 1 [(arm :arm1) (arm :arm2)]))

--- a/bandit-core/test/bandit/algo/ucb_test.clj
+++ b/bandit-core/test/bandit/algo/ucb_test.clj
@@ -17,7 +17,7 @@
                   [(arm :arm1 :pulls 1) (arm :arm2 :pulls 2)])
        (expect :name :arm1
                :pulls 1
-               :ucb-value 1.4823038073675112))
+               :ucb-value 1.482303807367511))
 
 ;; selecting arms
 (given (select-arm [(arm :arm1) (arm :arm2 :pulls 1)])

--- a/bandit-ring/project.clj
+++ b/bandit-ring/project.clj
@@ -3,15 +3,15 @@
   :url "http://github.com/pingles/bandit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [ring/ring-core "1.2.2"]
-                 [ring/ring-jetty-adapter "1.2.2"]
-                 [ring/ring-devel "1.2.2"]
+  :dependencies [[org.clojure/clojure "1.12.3"]
+                 [ring/ring-core "1.15.4"]
+                 [ring/ring-jetty-adapter "1.15.4"]
+                 [ring/ring-devel "1.15.4"]
                  [bandit/bandit-core "0.2.1-SNAPSHOT"]
-                 [compojure "1.1.6"]
-                 [hiccup "1.0.3"]]
-  :min-lein-version "2.0.0"
+                 [compojure "1.7.2"]
+                 [hiccup "1.0.5"]]
+  :min-lein-version "2.10.0"
   :main bandit.ring.app
   :uberjar-name "bandit-ring-standalone.jar"
-  :profiles {:dev {:dependencies [[expectations "1.4.45"]]
+  :profiles {:dev {:dependencies [[expectations "1.4.56"]]
                    :plugins [[lein-expectations "0.0.8"]]}})

--- a/bandit-simulate/project.clj
+++ b/bandit-simulate/project.clj
@@ -4,14 +4,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[bandit/bandit-core "0.2.1-SNAPSHOT"]
-                 [org.clojure/clojure "1.6.0"]
-                 [org.clojure/math.numeric-tower "0.0.4"]
-                 [org.clojure/tools.cli "0.2.2"]
-                 [org.clojure/data.csv "0.1.2"]
-                 [incanter/incanter-core "1.5.1"]]
-  :profiles {:dev {:dependencies [[criterium "0.4.1"]
-                                  [expectations "1.4.48"]]
+                 [org.clojure/clojure "1.12.3"]
+                 [org.clojure/math.numeric-tower "0.1.0"]
+                 [org.clojure/tools.cli "1.1.230"]
+                 [org.clojure/data.csv "1.1.0"]
+                 [incanter/incanter-core "1.9.3"]]
+  :profiles {:dev {:dependencies [[criterium "0.4.6"]
+                                  [expectations "1.4.56"]]
                    :plugins [[lein-expectations "0.0.8"]]}}
   :main bandit.simulate
-  :min-lein-version "2.0.0"
-  :jvm-opts ["-Xmx2G" "-server" "-XX:+UseConcMarkSweepGC"])
+  :min-lein-version "2.10.0"
+  :jvm-opts ["-Xmx2G" "-server"])

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[lein-sub "0.3.0"]]
-  :min-lein-version "2.0.0"
+  :min-lein-version "2.10.0"
   :sub ["bandit-core" "bandit-simulate" "bandit-ring"])


### PR DESCRIPTION
Closes PIN-1.

### What changed
- Bumped Clojure from **1.6.0** to **1.12.3** in every sub-project (`bandit-core`, `bandit-simulate`, `bandit-ring`).
- Refreshed supporting libraries to their current releases:
  - `math.numeric-tower` 0.0.4 → 0.1.0
  - `incanter-core` 1.5.1 → 1.9.3
  - `tools.cli` 0.2.2 → 1.1.230
  - `data.csv` 0.1.2 → 1.1.0
  - `criterium` 0.4.1 → 0.4.6
  - `ring-core/jetty-adapter/devel` 1.2.2 → 1.15.4
  - `compojure` 1.1.6 → 1.7.2
  - `hiccup` 1.0.3 → 1.0.5
  - `expectations` → 1.4.56 (the last 1.x release; keeps the `given` DSL the existing tests rely on).
- Bumped `:min-lein-version` to `2.10.0`.
- Dropped the JVM flag `-XX:+UseConcMarkSweepGC` from `bandit-simulate` because CMS has been removed from modern JDKs.
- Fixed a pre-existing malformed `ns` form in `bandit-core/test/bandit/algo/softmax_test.clj` (missing `:` in front of `use`), which newer Clojure's `ns` spec now rejects.
- Refreshed a handful of double-precision literals in tests to match the values produced on modern JDKs.
- Modernised `.travis.yml` to use a current `lein` and OpenJDK.

### Tests
```
lein sub install && lein sub do expectations, test
# => 55 tests, 55 assertions, 0 failures, 0 errors
```