### PR TITLE
Fix StackOverflowError in softmax/select-arm 2-arity

### DIFF
--- a/bandit-core/src/bandit/algo/softmax.clj
+++ b/bandit-core/src/bandit/algo/softmax.clj
@@ -30,7 +30,7 @@
   "selects the arm to pull. a higher temperature causes the algorithm to
    favour experimentation. 0 < temperature < 1."
   ([temperature arms]
-     (select-arm (rand) arms))
+     (select-arm temperature (rand) arms))
   ([temperature rand-val arms]
      (or (first (unpulled arms))
          (first (filter (fn [{:keys [cumulative-p]}]

--- a/bandit-core/test/bandit/algo/softmax_test.clj
+++ b/bandit-core/test/bandit/algo/softmax_test.clj
@@ -23,3 +23,9 @@
   (expect (arm :arm1 :p 0.5 :cumulative-p 0.5 :pulls 10) (select-arm 1 0.05 arms))
   (expect (arm :arm2 :p 0.5 :cumulative-p 1.0 :pulls 10) (select-arm 1 0.91 arms))
   (expect (arm :arm2 :cumulative-p 0.9 :pulls 10) (select-arm 1 100 arms)))
+
+;; regression: the 2-arity variant must not infinitely recurse (GH issue #4).
+;; Previously `(select-arm temperature arms)` called `(select-arm (rand) arms)`,
+;; which looped back into itself and blew the stack. It should delegate to the
+;; 3-arity form. With unpulled arms we can assert a deterministic result.
+(expect (arm :arm1) (select-arm 1 [(arm :arm1) (arm :arm2)]))


### PR DESCRIPTION
Fixes [pingles/bandit#4](https://github.com/pingles/bandit/issues/4) — tracked on Linear as [PIN-2](https://linear.app/rvu/issue/PIN-2).

## Bug
The 2-arity `bandit.algo.softmax/select-arm` recursed into itself instead of delegating to the 3-arity body:

```clojure
([temperature arms]
   (select-arm (rand) arms))   ;; still 2 args -> infinite recursion
```

Each call passed `(rand)` as `temperature` and the same `arms`, so it kept matching the 2-arity and never reached the 3-arity implementation. Eventually the JVM blew the stack — exactly the `StackOverflowError` reported in the GitHub issue (originating from `softmax.clj:33`).

This is reachable from the simulation harness, which wires softmax as `(partial softmax/select-arm epsilon)` and then invokes it with `arms` only.

## Fix
Delegate to the 3-arity variant, preserving the caller's temperature:

```clojure
([temperature arms]
   (select-arm temperature (rand) arms))
```

## Tests
- Added a regression test in `softmax_test.clj` asserting the 2-arity now returns instead of overflowing.
- Full suite: `lein sub do expectations, test` — 56 tests, 56 assertions. The 4 remaining failures (`ucb_test`, `softmax_test` probability assertions, `exp3-test` weight) are **pre-existing on `main`** and caused by JDK floating-point representation differences on modern JVMs; they are unrelated to this change.