### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Clojure multi-armed bandit library organized as a Leiningen monorepo with three sub-projects:
+- `bandit-core` — Core library implementing bandit algorithms (Epsilon-Greedy, Softmax, UCB, Bayesian, EXP3)
+- `bandit-simulate` — Monte Carlo simulation runner (outputs CSV)
+- `bandit-ring` — Ring/Compojure web demo app (embedded Jetty, in-memory state)
+
+### Prerequisites
+
+- **JDK 11** (not JDK 14+ — `bandit-simulate` uses `-XX:+UseConcMarkSweepGC` which was removed in JDK 14)
+- **Leiningen 2.x** (installed at `/usr/local/bin/lein`)
+- `JAVA_HOME` must be set to `/usr/lib/jvm/java-11-openjdk-amd64`
+
+### Key commands
+
+| Task | Command | Working directory |
+|------|---------|-------------------|
+| Install all deps | `lein sub install` | `/workspace` |
+| Run all tests | `lein sub do expectations, test` | `/workspace` |
+| Run bandit-ring web app | `lein run 8080` | `/workspace/bandit-ring` |
+| Run simulation | `lein run -a bayes -n 10 -t 1000` | `/workspace/bandit-simulate` |
+
+### Gotchas
+
+- The README says `lein run -m bandit.ring.example-app` but this namespace does not exist. The correct command is `lein run 8080` (from within `bandit-ring/`), which uses the `:main bandit.ring.app` declared in `project.clj`.
+- The `bandit-ring` app's `-main` function requires a port number as an argument.
+- `bandit-simulate` emits a JVM deprecation warning about `UseConcMarkSweepGC` on JDK 11 — this is harmless.
+- All state in `bandit-ring` is in-memory (Clojure refs); no external databases or services are needed.
+- The `bandit-ring` project depends on `bandit-core` being installed to the local Maven repo first (`lein sub install` handles this).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Overview of the monorepo structure (bandit-core, bandit-simulate, bandit-ring)
- Prerequisites (JDK 11, Leiningen 2.x, JAVA_HOME)
- Key commands table for install, test, run
- Gotchas discovered during setup (outdated README command, JVM GC flag deprecation, port argument requirement)

### Environment verification

All services were verified working:

- **Tests**: 55 tests passing across all sub-projects via `lein sub do expectations, test`
- **Web app**: `bandit-ring` running on port 8080 with both adverts and ranking examples functioning
- **Simulation**: `bandit-simulate` producing CSV output correctly

### Demo

[bandit_app_demo.mp4](https://cursor.com/agents/bc-f6b609d5-447b-4bca-9dbe-4872b2554551/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbandit_app_demo.mp4)

Multi-armed bandit optimization demo showing ranking reordering and ad click-through tracking.

[Bandit state after clicking advert](https://cursor.com/agents/bc-f6b609d5-447b-4bca-9dbe-4872b2554551/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbandit_state_updated.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6b609d5-447b-4bca-9dbe-4872b2554551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6b609d5-447b-4bca-9dbe-4872b2554551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

