### PR TITLE
Fix softmax select-arm infinite recursion (issue #4)

### DIFF
--- a/bandit-core/src/bandit/algo/softmax.clj
+++ b/bandit-core/src/bandit/algo/softmax.clj
@@ -30,7 +30,7 @@
   "selects the arm to pull. a higher temperature causes the algorithm to
    favour experimentation. 0 < temperature < 1."
   ([temperature arms]
-     (select-arm (rand) arms))
+     (select-arm temperature (rand) arms))
   ([temperature rand-val arms]
      (or (first (unpulled arms))
          (first (filter (fn [{:keys [cumulative-p]}]

--- a/bandit-core/test/bandit/algo/softmax_test.clj
+++ b/bandit-core/test/bandit/algo/softmax_test.clj
@@ -23,3 +23,10 @@
   (expect (arm :arm1 :p 0.5 :cumulative-p 0.5 :pulls 10) (select-arm 1 0.05 arms))
   (expect (arm :arm2 :p 0.5 :cumulative-p 1.0 :pulls 10) (select-arm 1 0.91 arms))
   (expect (arm :arm2 :cumulative-p 0.9 :pulls 10) (select-arm 1 100 arms)))
+
+;; regression: 2-arity select-arm must not infinitely recurse (issue #4)
+(expect (arm :arm1) (select-arm 1 [(arm :arm1) (arm :arm2)]))
+(let [arms   [(arm :arm1 :pulls 10 :value 1)
+              (arm :arm2 :pulls 10 :value 1)]
+      chosen (select-arm 0.1 arms)]
+  (expect true (contains? #{:arm1 :arm2} (:name chosen))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4. The 2-arity `bandit.algo.softmax/select-arm` recursively dispatched to itself instead of the 3-arity overload, which dropped the `temperature` argument and produced infinite recursion on the very first call — the exact `StackOverflowError` reported in the issue:

```
java.lang.StackOverflowError
  softmax.clj:33 bandit.algo.softmax/select-arm
  softmax.clj:33 bandit.algo.softmax/select-arm
  ...
```

### Root cause

`bandit-core/src/bandit/algo/softmax.clj`:

```clojure
([temperature arms]
   (select-arm (rand) arms))   ;; <- still 2-arity, recurses forever
```

### Fix

Forward `temperature` to the 3-arity implementation:

```clojure
([temperature arms]
   (select-arm temperature (rand) arms))
```

### Regression test

Added two assertions in `bandit-core/test/bandit/algo/softmax_test.clj` that exercise the 2-arity entry point so this regresses loudly if it returns.

## Testing

- `lein test` (bandit-core): 57 tests, 0 failures, 0 errors.
- REPL smoke test of the 2-arity entry point returns a valid arm instead of overflowing the stack.

## Note on the other open issue

Issue #1 (`No such var: a/mk-arms`) is already resolved by README changes — `bandit.arms` now exposes `bandit` (not `mk-arms`) and the README uses `a/bandit`. No code change is required; it can be closed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-244ad4cf-2168-400b-b94a-3bc9f32f6fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-244ad4cf-2168-400b-b94a-3bc9f32f6fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

